### PR TITLE
Change the way the main class is specified

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ application {
      * This is scheduled to be removed in Gradle 8.0. Use #getMainClass().set(...) instead.
      * See https://docs.gradle.org/6.7/dsl/org.gradle.api.plugins.JavaApplication.html#org.gradle.api.plugins.JavaApplication:mainClass for more details.
      */
-    setMainClassName('info.sciman.Main')
+    getMainClass().set('info.sciman.Main')
 }
 
 test {


### PR DESCRIPTION
I put a note about why I set the main class in a particular way and then forgot to actually do that. This PR gets rid of the deprecation warning when building.

.-.

whoops